### PR TITLE
Ensure tickets issued are unique in the database. 

### DIFF
--- a/ekip/config/settings/base.py
+++ b/ekip/config/settings/base.py
@@ -35,11 +35,15 @@ DJANGO_APPS = (
 
 # Apps specific to this project go here.
 LOCAL_APPS = (
-    'corsheaders',
     'ticketer.recordlocator',
 )
 
-INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS
+THIRD_PARTY_APPS = (
+    'corsheaders',
+    'localflavor',
+)
+
+INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/ekip/ticketer/recordlocator/admin.py
+++ b/ekip/ticketer/recordlocator/admin.py
@@ -1,3 +1,9 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Ticket
+
+
+class TicketAdmin(admin.ModelAdmin):
+    fields = ('record_locator', 'zip_code')
+
+admin.site.register(Ticket, TicketAdmin)

--- a/ekip/ticketer/recordlocator/migrations/0002_auto_20150602_1820.py
+++ b/ekip/ticketer/recordlocator/migrations/0002_auto_20150602_1820.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import localflavor.us.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recordlocator', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ticket',
+            name='zip_code',
+            field=localflavor.us.models.USZipCodeField(max_length=10),
+        ),
+    ]

--- a/ekip/ticketer/recordlocator/migrations/0003_auto_20150610_1901.py
+++ b/ekip/ticketer/recordlocator/migrations/0003_auto_20150610_1901.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recordlocator', '0002_auto_20150602_1820'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ticket',
+            name='record_locator',
+            field=models.CharField(max_length=16),
+        ),
+    ]

--- a/ekip/ticketer/recordlocator/models.py
+++ b/ekip/ticketer/recordlocator/models.py
@@ -1,12 +1,16 @@
 from django.db import models
 
+from localflavor.us.models import USZipCodeField
+
 # Create your models here.
 class RedemptionLocation(models.Model):
-	name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
 
 
 class Ticket(models.Model):
-	zip_code = models.CharField(max_length=5)
-	record_locator = models.CharField(max_length=8)
-	created = models.DateTimeField(auto_now_add=True)
-	redeemed = models.ForeignKey(RedemptionLocation, blank=True, null=True)
+    """ This is a ticket. """
+
+    zip_code = USZipCodeField(max_length=5)
+    record_locator = models.CharField(max_length=8)
+    created = models.DateTimeField(auto_now_add=True)
+    redeemed = models.ForeignKey(RedemptionLocation, blank=True, null=True)

--- a/ekip/ticketer/recordlocator/models.py
+++ b/ekip/ticketer/recordlocator/models.py
@@ -11,6 +11,9 @@ class Ticket(models.Model):
     """ This is a ticket. """
 
     zip_code = USZipCodeField(max_length=5)
-    record_locator = models.CharField(max_length=8)
+    record_locator = models.CharField(max_length=16)
     created = models.DateTimeField(auto_now_add=True)
     redeemed = models.ForeignKey(RedemptionLocation, blank=True, null=True)
+
+    def __str__(self):
+        return "%s %s" % (self.record_locator, self.zip_code)

--- a/ekip/ticketer/recordlocator/tests.py
+++ b/ekip/ticketer/recordlocator/tests.py
@@ -1,37 +1,59 @@
 import json
+from unittest import mock
 
 from django.test import TestCase
 from django.test import Client
 
-from .views import create_new_ticket, generate_backup_locator, create_tickets
+from ticketer.recordlocator import views
 from .models import Ticket
+
+
+def mock_generator(length=1):
+    return 'XXXXXXXX'
+
 
 class TicketCreationTests(TestCase):
     def test_create_new_ticket(self):
         """ Test the creation of a new ticket. """
-        create_new_ticket(20852, 'XXYZZYCD')
+        views.create_new_ticket(20852, 'XXYZZYCD')
         ticket = Ticket.objects.filter(record_locator='XXYZZYCD')[0]
         self.assertEqual(ticket.zip_code, '20852')
 
     def test_generate_backup_locator(self):
-        locator = generate_backup_locator()
+        locator = views.generate_backup_locator()
         self.assertTrue('-' in locator)
         self.assertEqual(16, len(locator))
 
     def test_create_tickets(self):
-        locators, failures = create_tickets(20852, 5)
+        locators, failures = views.create_tickets(20852, 5)
         self.assertEqual(5, len(locators) + len(failures))
 
-        #Failures should be extremely rare
+        # Failures should be extremely rare
         self.assertTrue(len(locators) > 0)
 
-        #Locators are unique with respect to each other. 
+        # Locators are unique with respect to each other.
         self.assertEqual(len(locators), len(set(locators)))
 
         for l in locators:
             ticket = Ticket.objects.get(record_locator=l)
             self.assertNotEqual(None, ticket)
             self.assertEqual(ticket.zip_code, '20852')
+
+    @mock.patch(
+        'ticketer.recordlocator.views.generator.safe_generate', mock_generator)
+    def test_create_unique_ticket(self):
+        locator_one = views.create_unique_ticket(16801)
+        self.assertEqual(locator_one, 'XXXXXXXX')
+
+        locator_two = views.create_unique_ticket(16801)
+        self.assertTrue('-' in locator_two)
+        self.assertTrue('XXXXXXXX' in locator_two)
+
+        locator_three = views.create_unique_ticket(20002)
+        self.assertTrue('-' in locator_two)
+        self.assertTrue('XXXXXXXX' in locator_two)
+
+        self.assertNotEqual(locator_two, locator_three)
 
 
 class RecordLocatorAPITests(TestCase):
@@ -58,6 +80,7 @@ class RecordLocatorAPITests(TestCase):
         response = c.get('/ticket/?n=100')
         self.assertEqual(400, response.status_code)
 
+
 class TicketGeneratorTest(TestCase):
     """ Tests for the RecordLocator API. """
 
@@ -66,4 +89,7 @@ class TicketGeneratorTest(TestCase):
         response = c.get('/ticket/?zip=91381')
         self.assertEqual(response.status_code, 200)
         r = json.loads(response.content.decode('utf8'))
-        self.assertEqual('91381', Ticket.objects.get(record_locator=r['record_locators'][0]).zip_code)
+        self.assertEqual(
+            '91381',
+            Ticket.objects.get(
+                record_locator=r['record_locators'][0]).zip_code)

--- a/ekip/ticketer/recordlocator/tests.py
+++ b/ekip/ticketer/recordlocator/tests.py
@@ -9,6 +9,9 @@ from .models import Ticket
 
 
 def mock_generator(length=1):
+    """ A mock record locator generator that returns the same record locator
+    each time. """
+
     return 'XXXXXXXX'
 
 

--- a/ekip/ticketer/recordlocator/views.py
+++ b/ekip/ticketer/recordlocator/views.py
@@ -22,10 +22,7 @@ def record_locators(request):
         return HttpResponseBadRequest(
             'Maximum of %s record locators can be requested' % MAX_REQUESTABLE)
 
-    record_locators = generate_locators(num_locators)
-
-    tickets = [Ticket(zip_code=zip_code, record_locator=record_locator) for record_locator in record_locators]
-    Ticket.objects.bulk_create(tickets)
+    record_locators = create_tickets(zip_code, num_locators)
 
     data = {'record_locators': record_locators}
     response = json.dumps(data)
@@ -33,8 +30,62 @@ def record_locators(request):
     return HttpResponse(response, content_type='application/json')
 
 
-def generate_locators(n=1):
-    """ Generate 'n' unique record locators. """
+def locator_exists(locator):
+    """ Return True if this locator already exists in the Ticket database. """
+    return Ticket.objects.filter(record_locator=locator).exists()
 
-    record_locators = [generator.safe_generate() for r in range(0, n)]
-    return record_locators
+
+def create_unique_ticket(zip_code):
+    """ This will attempt to create a unique Ticket (as identified by record
+    locator). It tries a couple times, before using a separate scheme for
+    Ticket generation. If that fails, this currently fails. We might later want
+    to explore modes where this never fails. """
+
+    locator = generator.safe_generate()
+    if not locator_exists(locator):
+        create_new_ticket(zip_code, locator)
+    else:
+        # Locator is already used, generate another one.
+        locator = generator.safe_generate()
+        if not locator_exists(locator):
+            create_new_ticket(zip_code, locator)
+        else:
+            # Second locator is also used, generate a completely different
+            # type.
+            locator = generator.generate_backup_locator()
+            if not locator_exists(locator):
+                create_new_ticket(zip_code, locator)
+            else:
+                # Trying infinitely doesn't make sense. Fail.
+                locator = None
+    return locator
+
+
+def create_tickets(zip_code, num_locators=1):
+    """ Create tickets, ensuring that the associated record locators are
+    unique. Return the list of those locators corresponding to new tickets. """
+
+    locators = []
+    failures = []
+
+    for r in range(0, num_locators):
+        locator = create_unique_ticket(zip_code)
+        if locator:
+            locators.append(locator)
+        else:
+            failures.append(locator)
+    return locators
+
+
+def create_new_ticket(zip_code, locator):
+    """ Create and save a ticket. """
+
+    ticket = Ticket(zip_code=zip_code, record_locator=locator)
+    ticket.save()
+
+
+def generate_backup_locator():
+    """ This generates a 16 character locator when we keep generating
+    duplicates. """
+    return generator.timestamp_generate()
+

--- a/ekip/ticketer/recordlocator/views.py
+++ b/ekip/ticketer/recordlocator/views.py
@@ -88,4 +88,3 @@ def generate_backup_locator():
     """ This generates a 16 character locator when we keep generating
     duplicates. """
     return generator.timestamp_generate()
-

--- a/ekip/ticketer/recordlocator/views.py
+++ b/ekip/ticketer/recordlocator/views.py
@@ -22,7 +22,7 @@ def record_locators(request):
         return HttpResponseBadRequest(
             'Maximum of %s record locators can be requested' % MAX_REQUESTABLE)
 
-    record_locators = create_tickets(zip_code, num_locators)
+    record_locators, _ = create_tickets(zip_code, num_locators)
 
     data = {'record_locators': record_locators}
     response = json.dumps(data)
@@ -74,7 +74,7 @@ def create_tickets(zip_code, num_locators=1):
             locators.append(locator)
         else:
             failures.append(locator)
-    return locators
+    return locators, failures
 
 
 def create_new_ticket(zip_code, locator):

--- a/ekip/ticketer/recordlocator/views.py
+++ b/ekip/ticketer/recordlocator/views.py
@@ -52,7 +52,7 @@ def create_unique_ticket(zip_code):
         else:
             # Second locator is also used, generate a completely different
             # type.
-            locator = generator.generate_backup_locator()
+            locator = generate_backup_locator()
             if not locator_exists(locator):
                 create_new_ticket(zip_code, locator)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dj-database-url
 waitress==0.8.9
 whitenoise==1.0.6
 django-cors-headers
+django-localflavor
 
 # Recordlocator
 -e git+https://github.com/18F/record-locator.git#egg=recordlocator


### PR DESCRIPTION
We issue record locators that are randomly generated. This attempts to ensure that those are unique (by checking against the database). 
