### PR TITLE
Putting the entire website behind a login wall. 

### DIFF
--- a/ekip/config/settings/base.py
+++ b/ekip/config/settings/base.py
@@ -60,6 +60,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'everykid.middleware.LoginRequiredMiddleware',
 )
 
 ROOT_URLCONF = 'config.urls'

--- a/ekip/config/settings/test.py
+++ b/ekip/config/settings/test.py
@@ -1,5 +1,17 @@
 from .base import *
 
+#Do not include the LoginRequiredMiddleware
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
 
 # The test database can just be sqlite.
 DATABASES = {

--- a/ekip/everykid/middleware.py
+++ b/ekip/everykid/middleware.py
@@ -1,0 +1,17 @@
+from django.http import HttpResponseRedirect
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from re import compile
+
+EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
+    EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+
+class LoginRequiredMiddleware:
+    
+    def process_request(self, request):
+        if not request.user.is_authenticated():
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return HttpResponseRedirect(
+                    settings.LOGIN_URL + "?next=" + request.path)


### PR DESCRIPTION
We need to put the entire website behind a login wall. 

This accomplishes this using Django middleware (and ensures that the middleware isn't used during tests). 
