### PR TITLE
Do not know zipcode link

### DIFF
--- a/ekip/everykid/templates/get-your-pass/game_success.html
+++ b/ekip/everykid/templates/get-your-pass/game_success.html
@@ -40,10 +40,10 @@
 
       {% endfor %}
 
-
       <button>Get my pass</button>
     </form>
 
+    <p><a href="{% url 'fourth_grade_voucher' %}?zip=00000">I don't know my ZIP code</a>.</p>
   </div>
 
 {% endblock content %}


### PR DESCRIPTION
This adds a link that allows kids to bypass the ZIP code form by saying 'I don't know my zipcode' This needs some front-end help, but the link works. 
