### PR TITLE
Shortens headline

### DIFF
--- a/ekip/everykid/templates/legal/privacy.html
+++ b/ekip/everykid/templates/legal/privacy.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<h1> Every Kid in a Park privacy policy </h1>
+<h1> Privacy policy </h1>
 
 <h2>Fourth graders</h2>
 <p>We don't collect any information that could personally identify you. 


### PR DESCRIPTION
I think it'll look cleaner if we just say "Privacy policy." People know which site they're on (I hope).
