### PR TITLE
Replaced Privacy Policy link

### DIFF
--- a/ekip/everykid/templates/base.html
+++ b/ekip/everykid/templates/base.html
@@ -51,7 +51,7 @@
             <a href="{% url 'about_ekip' %}">About Every Kid in a Park</a>
           </li>
           <li>
-            <a href="{% url 'privacy_policy' %}">Privacy policy</a>
+            <a href="https://www.doi.gov/privacy">Privacy Policy</a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
Replaced url w/ direct link for Privacy Policy per the Privacy Office.  We can still link out to Privacy Statement for input form pages from links at point of data collection.
