### PR TITLE
Adds DAP code

### DIFF
--- a/ekip/everykid/templates/base.html
+++ b/ekip/everykid/templates/base.html
@@ -76,5 +76,8 @@
     ga('send', 'pageview');
   </script>
 
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOI"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Ports the DAP central hosting snippet include over from https://github.com/18F/ekip/pull/130. The flag was set, but the DAP wasn't being reported to.
