### PR TITLE
Change the voucher url from planyourtrip to plan-your-trip/. 

### DIFF
--- a/ekip/everykid/templates/get-your-pass/educator_vouchers.html
+++ b/ekip/everykid/templates/get-your-pass/educator_vouchers.html
@@ -42,7 +42,7 @@
         </li>
         <li class="plan">
           <h2>Hit the road</h2>
-          <p>Plan your trip at www.everykidinapark.gov/planyourtrip</p>
+          <p>Plan your trip at www.everykidinapark.gov/plan-your-trip/</p>
         </li>
         <li class="get">
           <h2>Get your pass and get in free!</h2>

--- a/ekip/everykid/templates/get-your-pass/fourth_grade_voucher.html
+++ b/ekip/everykid/templates/get-your-pass/fourth_grade_voucher.html
@@ -50,7 +50,7 @@
         </li>
         <li class="plan">
           <h2>Hit the road</h2>
-          <p>Plan your trip at www.everykidinapark.gov/planyourtrip</p>
+          <p>Plan your trip at www.everykidinapark.gov/plan-your-trip/</p>
         </li>
         <li class="get">
           <h2>Get your pass and get in free!</h2>

--- a/ekip/everykid/tests.py
+++ b/ekip/everykid/tests.py
@@ -35,6 +35,10 @@ class BasicPageTestCase(TestCase):
         response = self.client.get(reverse('field_trip'))
         self.assertEquals(200, response.status_code)
 
+    def test_planyoutrip(self):
+        response = self.client.get(reverse('redirect_planner'))
+        self.assertEquals(302, response.status_code)
+
 
 class NavigationTestCase(TestCase):
     def setUp(self):

--- a/ekip/everykid/urls.py
+++ b/ekip/everykid/urls.py
@@ -5,7 +5,7 @@ from django.views.decorators.cache import cache_page
 from .views import (
     student_pass, pass_exchange, educator_vouchers,
     EducatorFormPreview, fourth_grade_voucher, game_success, field_trip,
-    field_trip_details)
+    field_trip_details, planyourtrip)
 
 from .forms import EducatorForm
 
@@ -34,6 +34,7 @@ urlpatterns = patterns(
         template_name="get-your-pass/index.html")), name="get_your_pass"),
 
     # PLAN YOUR TRIP
+    url(r'planyourtrip', planyourtrip, name='redirect_planner'),
     url(
         r'plan-your-trip/field-trip/(?P<slug>[-\w]+)/$',
         cache_page(60*60)(field_trip_details), name="field_trip_details"),

--- a/ekip/everykid/views.py
+++ b/ekip/everykid/views.py
@@ -15,6 +15,11 @@ STATES = {abbr: name for abbr, name in US_STATES}
 STATES['PR'] = 'Puerto Rico'
 STATES['VI'] = 'Virgin Islands'
 
+def planyourtrip(request):
+    # We launched with /planyoutrip printed on the vouchers. 
+    # Make that URL work. 
+    return HttpResponseRedirect(reverse('plan_your_trip'))
+
 
 def plan_your_trip(request):
     return render(


### PR DESCRIPTION
We change the URL that's displayed on the voucher page. 
We make the previous URL (that did not work), work. 

Fixes: https://github.com/18F/ekip/issues/162
