### PR TITLE
Add Red Rock Canyon to the pass exchange site list

### DIFF
--- a/ekip/nationalparks/data/red-rock.csv
+++ b/ekip/nationalparks/data/red-rock.csv
@@ -1,0 +1,1 @@
+Red Rock Canyon National Conservation Area BLM,702-515-5350,Las Vegas,NV,http://www.nv.blm.gov/redrockcanyon,YES,YES,YES

--- a/ekip/nationalparks/management/commands/slugify.py
+++ b/ekip/nationalparks/management/commands/slugify.py
@@ -82,7 +82,8 @@ class Command(BaseCommand):
     """ Assign a slug to each FederalSite in the database. """
 
     def handle(self, *args, **options):
-        sites = FederalSite.objects.all()
+        #Only assign slugs to objects that don't have one. 
+        sites = FederalSite.objects.filter(slug__isnull=True)
 
         slug = ''
         for site in sites:


### PR DESCRIPTION
I update the slugify command for now so that we don't re-slug existing sites. 
This adds in a data file with a single entry, so that I can use that to load this one site. 
