### PR TITLE
Add a missing index

### DIFF
--- a/ekip/ticketer/recordlocator/migrations/0007_auto_20150910_1411.py
+++ b/ekip/ticketer/recordlocator/migrations/0007_auto_20150910_1411.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recordlocator', '0006_additionalredemption'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ticket',
+            name='record_locator',
+            field=models.CharField(db_index=True, max_length=16),
+        ),
+    ]

--- a/ekip/ticketer/recordlocator/models.py
+++ b/ekip/ticketer/recordlocator/models.py
@@ -9,7 +9,7 @@ class Ticket(models.Model):
     """ This is a voucher. """
 
     zip_code = USZipCodeField(max_length=5)
-    record_locator = models.CharField(max_length=16)
+    record_locator = models.CharField(max_length=16, db_index=True)
     created = models.DateTimeField(auto_now_add=True)
 
     recreation_site = models.ForeignKey(FederalSite, null=True)


### PR DESCRIPTION
When we generate educator passes in production, we're seeing huge hits to the database. Turns out I was missing an index on the table. 

This adds that index. 
