### PR TITLE
Changed campground to campsite

### DIFF
--- a/ekip/everykid/templates/plan-your-trip/index.html
+++ b/ekip/everykid/templates/plan-your-trip/index.html
@@ -96,7 +96,7 @@
         <h2>Get a place to stay</h2>
 
         <p>Your family may want to stay somewhere overnight. You can reserve a cabin or
-        campground on <a href="http://www.recreation.gov">recreation.gov</a>.</p>
+        campsite on <a href="http://www.recreation.gov">recreation.gov</a>.</p>
 
       </div>
 


### PR DESCRIPTION
Per Rec.gov folks, since campground refers to a collection of campsites - campsite is more accurate.

https://github.com/18F/ekip/issues/189
