### PR TITLE
Educator limits

### DIFF
--- a/ekip/everykid/migrations/0005_auto_20150923_1919.py
+++ b/ekip/everykid/migrations/0005_auto_20150923_1919.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('everykid', '0004_auto_20150818_1835'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='educator',
+            name='num_students',
+            field=models.IntegerField(validators=[django.core.validators.MaxValueValidator(50), django.core.validators.MinValueValidator(1)], help_text='Number of students for which you are requesting vouchers', verbose_name='Number of students'),
+        ),
+    ]

--- a/ekip/everykid/migrations/0006_auto_20150923_2041.py
+++ b/ekip/everykid/migrations/0006_auto_20150923_2041.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('everykid', '0005_auto_20150923_1919'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='educator',
+            name='num_students',
+            field=models.IntegerField(help_text='Number of students for which you are requesting vouchers', validators=[django.core.validators.MaxValueValidator(50, 'You can only print up to 50 passes at a time.'), django.core.validators.MinValueValidator(1, 'You can not print less than one pass.')], verbose_name='Number of students'),
+        ),
+    ]

--- a/ekip/everykid/models.py
+++ b/ekip/everykid/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.core.validators import MaxValueValidator, MinValueValidator
 
 from localflavor.us.models import USStateField, USZipCodeField
 
@@ -26,4 +27,8 @@ class Educator(models.Model):
     zipcode = USZipCodeField(_("Zip"))
     num_students = models.IntegerField(
         _("Number of students"),
+        validators=[
+            MaxValueValidator(
+                50, _('You can only print up to 50 passes at at time.')),
+            MinValueValidator(1, _('You can not print less than one pass.'))],
         help_text="Number of students for which you are requesting vouchers")

--- a/ekip/everykid/models.py
+++ b/ekip/everykid/models.py
@@ -29,6 +29,6 @@ class Educator(models.Model):
         _("Number of students"),
         validators=[
             MaxValueValidator(
-                50, _('You can only print up to 50 passes at at time.')),
+                50, _('You can only print up to 50 passes at a time.')),
             MinValueValidator(1, _('You can not print less than one pass.'))],
         help_text="Number of students for which you are requesting vouchers")

--- a/ekip/everykid/templates/get-your-pass/educator_form.html
+++ b/ekip/everykid/templates/get-your-pass/educator_form.html
@@ -23,6 +23,7 @@
         {% endif %}
           <div class="{{ field.html_name }}{% if field.errors %} error{% endif %}">
             {{ field.label_tag }}
+            {{ field.errors }}
             {{ field }}
           </div>
         {% if field.html_name != 'state' %}

--- a/ekip/everykid/templates/get-your-pass/educator_passes.html
+++ b/ekip/everykid/templates/get-your-pass/educator_passes.html
@@ -58,6 +58,9 @@
 
       {% include "get-your-pass/educator_form.html" %}
 
+      <p>You can only print up to 50 passes at a time. To print more
+      than 50 passes, just fill this form out again.</p>
+
       <input type="hidden" name="{{stage_field}}" value="1" />
       <button type="submit">Next:<br/><span>Review Information</span></button>
     </form>

--- a/ekip/everykid/tests.py
+++ b/ekip/everykid/tests.py
@@ -102,6 +102,29 @@ class EducatorFormTests(TestCase):
             self.assertFormError(
                 response, 'form', field, 'This field is required.')
 
+    def test_number_of_passes_limit(self):
+        """ On the educator form, we can only request 50 passes at a time. Test
+        that this is enforced. """
+
+        response = self.client.post(
+            '/get-your-pass/educator/',
+            {
+                'work_email': 'rj@teach.org',
+                'stage': '1',
+                'name': 'Rajiv Teacher',
+                'organization_name': 'Zion Elementary',
+                'address_line_1': '1 Main St.',
+                'city': 'Austin',
+                'state': 'TX',
+                'zipcode': '78704',
+                'num_students': '61',
+                'org_or_school': 'S'
+            })
+
+        self.assertFormError(
+            response, 'form', 'num_students',
+            'You can only print up to 50 passes at a time.')
+
     def test_create_educator(self):
         """ Test the create_educator function. """
         data = {

--- a/ekip/everykid/tests.py
+++ b/ekip/everykid/tests.py
@@ -102,7 +102,7 @@ class EducatorFormTests(TestCase):
             self.assertFormError(
                 response, 'form', field, 'This field is required.')
 
-    def test_number_of_passes_limit(self):
+    def test_max_number_of_passes_limit(self):
         """ On the educator form, we can only request 50 passes at a time. Test
         that this is enforced. """
 
@@ -124,6 +124,31 @@ class EducatorFormTests(TestCase):
         self.assertFormError(
             response, 'form', 'num_students',
             'You can only print up to 50 passes at a time.')
+
+    def test_min_number_of_passes_limit(self):
+        """ On the educator form, we can not request fewer than 1 pass. 
+        Test that this is enforced. """
+
+        response = self.client.post(
+            '/get-your-pass/educator/',
+            {
+                'work_email': 'rj@teach.org',
+                'stage': '1',
+                'name': 'Rajiv Teacher',
+                'organization_name': 'Zion Elementary',
+                'address_line_1': '1 Main St.',
+                'city': 'Austin',
+                'state': 'TX',
+                'zipcode': '78704',
+                'num_students': '-10',
+                'org_or_school': 'S'
+            })
+
+        self.assertFormError(
+            response,
+            'form', 'num_students', 'You can not print less than one pass.')
+
+
 
     def test_create_educator(self):
         """ Test the create_educator function. """


### PR DESCRIPTION
Limit the number of passes that can be bulk printed. 

This limits that printing to 50 passes at a time, as we've recently seen abuses of this. 
