### PR TITLE
Corrects milestone and partner keys

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -46,23 +46,25 @@ testable: true
 team:
 - github: khandelwal
   role: 18F Product Lead, developer
+  id: khandelwal
 - github: openglobe
   role: DOI Activation Team Co-Lead, Presidential Innovation Fellow
-- id: Kat Currie
-  role: DOI Activation Team Co-Lead
+  id: christopher-goranson
+#- id: Kat Currie
+#  role: DOI Activation Team Co-Lead
 - github: ericronne
-  role: 18F Designer, UX
+  role: Designer, UX
 - github: xtine
   role: Front-End Developer
 - github: emileighoutlaw
   role: Content Writer, UX
 
 # Partners for whom the project is developed
-#partners:
+partners:
 - U.S. Department of the Interior
 
 # Brief descriptions of significant project developments
-#milestones:
+milestones:
 - February 2015 - PIF Design Studio
 - March 2015 - Mini-Hackathon
 - May 2015 - UMD Kid's Team Testing at White House


### PR DESCRIPTION
These were commented out which is likely what is causing many of the errors seen on the dashboard. Another thing that is causing errors is the inclusion of non-18F team members in this list. I will file an issue in 18F/about_yml to attempt to support that but in the mean time, let's leave these team members commented so that we can quickly re-add them when it's possible.
