### PR TITLE
Fixes the EKIP logo sizing responsively between about 518px and 800px.

### DIFF
--- a/ekip/everykid/static/css/style.css
+++ b/ekip/everykid/static/css/style.css
@@ -1600,7 +1600,8 @@ footer {
       width: 50%;
       top: 10px;
       left: 10px;
-      position: absolute; }
+      position: absolute;
+      max-width: 256px; }
       nav.mobile-menu .logo img {
         width: 100%; }
     nav.mobile-menu .menu-button {

--- a/ekip/everykid/static/css/style.css
+++ b/ekip/everykid/static/css/style.css
@@ -1600,8 +1600,7 @@ footer {
       width: 50%;
       top: 10px;
       left: 10px;
-      position: absolute;
-      max-width: 256px; }
+      position: absolute; }
       nav.mobile-menu .logo img {
         width: 100%; }
     nav.mobile-menu .menu-button {

--- a/ekip/everykid/static/scss/_responsive.scss
+++ b/ekip/everykid/static/scss/_responsive.scss
@@ -50,6 +50,7 @@
       top: 10px;
       left: 10px;
       position: absolute;
+      max-width: 256px;
 
       img {
         width: 100%;


### PR DESCRIPTION
Before:
<img width="1280" alt="screen shot 2016-06-06 at 10 13 46 am" src="https://cloud.githubusercontent.com/assets/5091167/15829120/8d6825ca-2bcf-11e6-9018-f3256f0654d0.png">
After:
<img width="1280" alt="screen shot 2016-06-06 at 10 14 25 am" src="https://cloud.githubusercontent.com/assets/5091167/15829124/9475a8b0-2bcf-11e6-9624-579056b7b662.png">
