### PR TITLE
Show sites with 4th grade pass acceptance instead of Annual passes.

### DIFF
--- a/ekip/nationalparks/api.py
+++ b/ekip/nationalparks/api.py
@@ -25,7 +25,7 @@ class FederalSiteResource(DjangoResource):
         if state:
             query = FederalSite.objects.filter(state=state)
         if everykid:
-            query = query.filter(annual_pass=True, active_participant=True)
+            query = query.filter(access_pass=True, active_participant=True)
 
         return query
 


### PR DESCRIPTION
Switched over Federal pass sites to show 4th grade pass acceptance sites instead of sites that accept annual passes.  

@khandelwal  @OpenGlobe 
