### PR TITLE
Support for python 3.4.2 was dropped. Updated to python 3.4.5

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.3
+python-3.4.5


### PR DESCRIPTION
It appears that CF buildpack support for python 3.4.2 was dropped recently . Updated it to the next supported version. https://github.com/cloudfoundry/python-buildpack/releases .
