### PR TITLE
Remove quantified code badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Every Kid in a Park (EKIP API)
 
 [![Coverage Status](https://coveralls.io/repos/18F/ekip-api/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/ekip-api?branch=master)
 
-[![Code Issues](https://www.quantifiedcode.com/api/v1/project/ecb305ac0bfa4e968192621402faface/badge.svg)](https://www.quantifiedcode.com/app/project/ecb305ac0bfa4e968192621402faface)
-
 
 #Introduction
 The [Every Kid in a Park] (https://www.whitehouse.gov/the-press-office/2015/02/19/fact-sheet-launching-every-kid-park-initiative-and-designating-new-natio) initiative is part of President Obama’s commitment to protect our Nation’s unique outdoor spaces and ensure that every American has the opportunity to visit and enjoy them.  This initiative provides all fourth grade students and their families with free admission to National Parks and other federal lands and waters for a full year.


### PR DESCRIPTION
Not only was it pointing to the wrong repo, but Quantified Code is shutting
down.

Resolves #224, though not in the way we expected
