### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/cf.sh
+++ b/cf.sh
@@ -1,3 +1,3 @@
 echo '-----Starting APP ----------'
 cd ekip
-newrelic-admin run-program waitress-serve --port=$VCAP_APP_PORT ekip.config.wsgi:application
+newrelic-admin run-program waitress-serve --port=$PORT ekip.config.wsgi:application


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
