### PR TITLE
Fix failing tests around the record locator API

### DIFF
--- a/ekip/config/settings/base.py
+++ b/ekip/config/settings/base.py
@@ -66,7 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages', 
-                'django.core.context_processors.request']
+                'django.template.context_processors.request']
         }
     }
 ]

--- a/ekip/config/urls.py
+++ b/ekip/config/urls.py
@@ -1,12 +1,11 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 
 from nationalparks.api import FederalSiteResource, FieldTripResource
 from ticketer.recordlocator.views import TicketResource
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'', include('everykid.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url('api/tickets/', include(TicketResource.urls())),
@@ -16,4 +15,4 @@ urlpatterns = patterns(
     url(r'^accounts/logout/$', auth_views.logout),
     url(r'^redeem/', include('redemption.urls')),
     url(r'^game/', include('game.urls')),
-)
+]

--- a/ekip/everykid/urls.py
+++ b/ekip/everykid/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import TemplateView
 from django.views.decorators.cache import cache_page
 
@@ -9,8 +9,7 @@ from .views import (
 
 from .forms import EducatorForm
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [ 
     url(r'^$', cache_page(60*60)(TemplateView.as_view(
         template_name="index.html")), name="main_landing"),
 
@@ -62,4 +61,4 @@ urlpatterns = patterns(
     # LEGAL
     url(r'privacy-policy/$', cache_page(60*60)(TemplateView.as_view(
         template_name="legal/privacy.html")), name="privacy_policy"),
-)
+]

--- a/ekip/game/urls.py
+++ b/ekip/game/urls.py
@@ -1,12 +1,11 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
 from .views import (
     nature_walk, nature_walk_end, time_travel, time_travel_end, swimming,
     swimming_end, game_start, choose_adventure_type)
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'first/one$', TemplateView.as_view(
         template_name='first-game/start.html'), name='first_game_start'),
     url(r'first/two$', TemplateView.as_view(
@@ -32,4 +31,4 @@ urlpatterns = patterns(
 
     url(r'adventure/swimming/end', swimming_end, name='swimming_end'),
     url(r'adventure/swimming', swimming, name='adventure_swimming'),
-)
+]

--- a/ekip/redemption/urls.py
+++ b/ekip/redemption/urls.py
@@ -1,9 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from redemption.views import redeem_confirm, redeem_for_site, sites_for_state
 from redemption.views import get_passes_state, statistics, tables, csv_redemption
 
-urlpatterns = patterns(
-    '', 
+urlpatterns = [ 
     url(r'statistics/$', statistics),
     url('data/exchanges/$', csv_redemption, name='exchanges_data'),
     url(r'data/$', tables),
@@ -11,4 +10,4 @@ urlpatterns = patterns(
     url(r'done/(?P<slug>[-\w]+)/$', redeem_confirm),
     url(r'sites/', sites_for_state),
     url(r'^$', get_passes_state),
-)
+]

--- a/ekip/ticketer/recordlocator/urls.py
+++ b/ekip/ticketer/recordlocator/urls.py
@@ -1,7 +1,0 @@
-from django.conf.urls import url
-
-from . import views
-
-urlpatterns = [
-    url(regex=r'^$', view=views.record_locators, name='generate_ticket'),
-]

--- a/ekip/ticketer/recordlocator/views.py
+++ b/ekip/ticketer/recordlocator/views.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from recordlocator import generator
 from restless.dj import DjangoResource
@@ -37,6 +37,7 @@ class TicketResource(DjangoResource):
         }
         return data
 
+
     @skip_prepare
     def issue(self, num_locators=1, zip_code=None):
         if self.request and 'num_locators' in self.request.GET:
@@ -54,12 +55,13 @@ class TicketResource(DjangoResource):
     @classmethod
     def urls(cls, name_prefix=None):
         urlpatterns = super(TicketResource, cls).urls(name_prefix=name_prefix)
-        return urlpatterns + patterns(
-            '',
+        new = [
             url(
                 r'^issue/', cls.as_view('issue'),
                 name=cls.build_url_name('issue', name_prefix)),
-        )
+        ] + urlpatterns
+        print(new)
+        return new
 
 
 def locator_exists(locator):

--- a/ekip/ticketer/recordlocator/views.py
+++ b/ekip/ticketer/recordlocator/views.py
@@ -60,7 +60,6 @@ class TicketResource(DjangoResource):
                 r'^issue/', cls.as_view('issue'),
                 name=cls.build_url_name('issue', name_prefix)),
         ] + urlpatterns
-        print(new)
         return new
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Django, using PostgreSQL
-Django
+Django==1.9.10
 psycopg2
 dj-database-url
 waitress==0.8.9
@@ -7,7 +7,7 @@ whitenoise==1.0.6
 django-cors-headers
 django-localflavor
 restless
-django-formtools
+-e git+https://github.com/django/django-formtools.git#egg=django-formtools
 boto
 newrelic==2.54.0.41
 


### PR DESCRIPTION
Previously, the following tests were failing: 

```
FAIL: test_api_generate_locators (ticketer.recordlocator.tests.RecordLocatorAPITests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/colincraig/ekip-api/ekip/ticketer/recordlocator/tests.py", line 71, in test_api_generate_locators
    self.assertEqual(response.status_code, 200)
AssertionError: 501 != 200

======================================================================
FAIL: test_api_multiple_locators (ticketer.recordlocator.tests.RecordLocatorAPITests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/colincraig/ekip-api/ekip/ticketer/recordlocator/tests.py", line 79, in test_api_multiple_locators
    self.assertEqual(response.status_code, 200)
AssertionError: 501 != 200

======================================================================
FAIL: test_ticket_zip_match (ticketer.recordlocator.tests.TicketGeneratorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/colincraig/ekip-api/ekip/ticketer/recordlocator/tests.py", line 91, in test_ticket_zip_match
    self.assertEqual(response.status_code, 200)
AssertionError: 501 != 200

----------------------------------------------------------------------
Ran 58 tests in 0.763s

FAILED (failures=3)
```

This is now fixed - by changing the order of the urls generated in a particular case. Also, this pull request upgrades Django (as seen in the Spanish translation pull request) and makes the necessary changes to the URL patterns (as the previous method was deprecated). 