### PR TITLE
Final Govcloud changes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd ekip && python manage.py migrate --settings=config.settings.production --noinput && gunicorn config.wsgi:application
+web: cd ekip && python manage.py migrate --settings=config.settings.production --noinput && waitress-serve --port=$PORT config.wsgi:application

--- a/cf.sh
+++ b/cf.sh
@@ -1,3 +1,3 @@
 echo '-----Starting APP ----------'
 cd ekip
-newrelic-admin run-program gunicorn ekip.config.wsgi:application
+newrelic-admin run-program waitress-serve --port=$PORT ekip.config.wsgi:application

--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -2,6 +2,8 @@ inherit: manifest.yml
 instances: 4
 routes:
   - route: ekip-prod.app.cloud.gov
+  - route: everykidinapark.gov
+  - route: www.everykidinapark.gov
 services:
   - ekip-newrelic
   - ekip-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Django==1.9.13
 psycopg2==2.7.1
 dj-database-url==0.4.2
-gunicorn==19.7.1
+waitress==0.8.9
 whitenoise==3.3.0
 django-cors-headers==2.0.2
 django-localflavor==1.4.1


### PR DESCRIPTION
Due to errors that popped up with Cloudfront + gunicorn, just reverted back to waitress for now.
Eventually should look back into going back to gunicorn (better performance under load) and also using this:
https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS


Also, forgot the prod routes in the prod manifest file.